### PR TITLE
Update svelteStormfinal.png:Zone.Identifier

### DIFF
--- a/assets/icons/linux/svelteStormfinal.png:Zone.Identifier
+++ b/assets/icons/linux/svelteStormfinal.png:Zone.Identifier
@@ -1,3 +1,3 @@
 [ZoneTransfer]
 ZoneId=3
-HostUrl=https://files.slack.com/files-pri/T0344D65VMF-F03H9UHSV3R/download/sveltestormfinal.png?origin_team=T0344D65VMF
+HostUrl=https://github.com/open-source-labs/SvelteStorm/blob/main/assets/icons/linux/icon.png?raw=true


### PR DESCRIPTION
To fix 
```
error: invalid path 'assets/icons/linux/svelteStormfinal.png:Zone.Identifier'
fatal: unable to checkout working tree
```
The host returns error 404 which lead to clone failure